### PR TITLE
Ensure diffusionplans module configures document directories

### DIFF
--- a/core/modules/modDiffusionPlans.class.php
+++ b/core/modules/modDiffusionPlans.class.php
@@ -83,8 +83,25 @@ class modDiffusionPlans extends DolibarrModules
 		// Key used in llx_const table to save module status enabled/disabled (where DIFFUSIONPLANS is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 
-		$conf->diffusionplans = new stdClass();
-    	$conf->diffusionplans->dir_output = './diffusionplans';
+                if (!isset($conf->diffusionplans) || !is_object($conf->diffusionplans)) {
+                        $conf->diffusionplans = new stdClass();
+                }
+
+                $entity = !empty($conf->entity) ? (int) $conf->entity : 1;
+                $defaultDir = DOL_DATA_ROOT.($entity > 1 ? '/'.$entity : '').'/diffusionplans';
+
+                if (empty($conf->diffusionplans->dir_output)) {
+                        $conf->diffusionplans->dir_output = $defaultDir;
+                }
+                if (empty($conf->diffusionplans->dir_temp)) {
+                        $conf->diffusionplans->dir_temp = $conf->diffusionplans->dir_output.'/temp';
+                }
+                if (empty($conf->diffusionplans->multidir_output) || !is_array($conf->diffusionplans->multidir_output)) {
+                        $conf->diffusionplans->multidir_output = array();
+                }
+                if (empty($conf->diffusionplans->multidir_output[$entity])) {
+                        $conf->diffusionplans->multidir_output[$entity] = $defaultDir;
+                }
 
 		// Name of image file used for this module.
 		// If file is in theme/yourtheme/img directory under name object_pictovalue.png, use this->picto='pictovalue'


### PR DESCRIPTION
## Summary
- ensure the diffusionplans module initialises its document storage directories with absolute paths for the active entity
- populate the temp and multidir outputs when missing to avoid TCPDF write errors

## Testing
- php -l core/modules/modDiffusionPlans.class.php

------
https://chatgpt.com/codex/tasks/task_e_68e3b2453cd4832e81d5b5e32a971c42