### PR TITLE
Ensure diffusion modulepart directories are registered

### DIFF
--- a/class/diffusion.class.php
+++ b/class/diffusion.class.php
@@ -25,6 +25,7 @@
 
 // Put here all includes required by your class file
 require_once DOL_DOCUMENT_ROOT.'/core/class/commonobject.class.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
 //require_once DOL_DOCUMENT_ROOT . '/societe/class/societe.class.php';
 //require_once DOL_DOCUMENT_ROOT . '/product/class/product.class.php';
 
@@ -183,17 +184,58 @@ class Diffusion extends CommonObject
 	 *
 	 * @param	DoliDB $db Database handler
 	 */
-	public function __construct(DoliDB $db)
-	{
-		global $langs;
+        public function __construct(DoliDB $db)
+        {
+                global $conf, $langs;
 
-		$this->db = $db;
-		$this->ismultientitymanaged = 0;
-		$this->isextrafieldmanaged = 1;
+                $this->db = $db;
+                $this->ismultientitymanaged = 0;
+                $this->isextrafieldmanaged = 1;
 
-		if (!getDolGlobalInt('MAIN_SHOW_TECHNICAL_ID') && isset($this->fields['rowid']) && !empty($this->fields['ref'])) {
-			$this->fields['rowid']['visible'] = 0;
-		}
+                $entity = !empty($conf->entity) ? (int) $conf->entity : 1;
+
+                if (!isset($conf->diffusionplans) || !is_object($conf->diffusionplans)) {
+                        $conf->diffusionplans = new stdClass();
+                }
+
+               if (empty($conf->diffusionplans->dir_output)) {
+                       $conf->diffusionplans->dir_output = DOL_DATA_ROOT.($entity > 1 ? '/'.$entity : '').'/diffusionplans';
+               }
+
+               if (empty($conf->diffusionplans->multidir_output) || !is_array($conf->diffusionplans->multidir_output)) {
+                       $conf->diffusionplans->multidir_output = array();
+               }
+
+               if (empty($conf->diffusionplans->multidir_output[$entity])) {
+                       $conf->diffusionplans->multidir_output[$entity] = $conf->diffusionplans->dir_output;
+               }
+
+               if (!isset($conf->diffusion) || !is_object($conf->diffusion)) {
+                       $conf->diffusion = new stdClass();
+               }
+
+               if (empty($conf->diffusion->dir_output)) {
+                       $conf->diffusion->dir_output = $conf->diffusionplans->dir_output.'/diffusion';
+               }
+
+               if (empty($conf->diffusion->multidir_output) || !is_array($conf->diffusion->multidir_output)) {
+                       $conf->diffusion->multidir_output = array();
+               }
+
+               if (empty($conf->diffusion->multidir_output[$entity])) {
+                       $conf->diffusion->multidir_output[$entity] = $conf->diffusion->dir_output;
+               }
+
+               $this->modulepart = 'diffusion';
+               $this->dir_output = $conf->diffusion->multidir_output[$entity];
+
+               if (!empty($this->dir_output)) {
+                       dol_mkdir($this->dir_output);
+               }
+
+                if (!getDolGlobalInt('MAIN_SHOW_TECHNICAL_ID') && isset($this->fields['rowid']) && !empty($this->fields['ref'])) {
+                        $this->fields['rowid']['visible'] = 0;
+                }
 		if (!isModEnabled('multicompany') && isset($this->fields['entity'])) {
 			$this->fields['entity']['enabled'] = 0;
 		}

--- a/class/diffusioncontact.class.php
+++ b/class/diffusioncontact.class.php
@@ -25,6 +25,7 @@
 
 // Put here all includes required by your class file
 require_once DOL_DOCUMENT_ROOT.'/core/class/commonobject.class.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
 //require_once DOL_DOCUMENT_ROOT . '/societe/class/societe.class.php';
 //require_once DOL_DOCUMENT_ROOT . '/product/class/product.class.php';
 
@@ -171,16 +172,57 @@ class DiffusionContact extends CommonObject
 	 *
 	 * @param	DoliDB $db Database handler
 	 */
-	public function __construct(DoliDB $db)
-	{
-		global $langs;
+        public function __construct(DoliDB $db)
+        {
+                global $conf, $langs;
 
-		$this->db = $db;
-		$this->ismultientitymanaged = 0;
-		$this->isextrafieldmanaged = 1;
+                $this->db = $db;
+                $this->ismultientitymanaged = 0;
+                $this->isextrafieldmanaged = 1;
 
-		if (!getDolGlobalInt('MAIN_SHOW_TECHNICAL_ID') && isset($this->fields['rowid']) && !empty($this->fields['ref'])) {
-			$this->fields['rowid']['visible'] = 0;
+                $entity = !empty($conf->entity) ? (int) $conf->entity : 1;
+
+                if (!isset($conf->diffusionplans) || !is_object($conf->diffusionplans)) {
+                        $conf->diffusionplans = new stdClass();
+                }
+
+               if (empty($conf->diffusionplans->dir_output)) {
+                       $conf->diffusionplans->dir_output = DOL_DATA_ROOT.($entity > 1 ? '/'.$entity : '').'/diffusionplans';
+               }
+
+               if (empty($conf->diffusionplans->multidir_output) || !is_array($conf->diffusionplans->multidir_output)) {
+                       $conf->diffusionplans->multidir_output = array();
+               }
+
+               if (empty($conf->diffusionplans->multidir_output[$entity])) {
+                       $conf->diffusionplans->multidir_output[$entity] = $conf->diffusionplans->dir_output;
+               }
+
+               if (!isset($conf->diffusioncontact) || !is_object($conf->diffusioncontact)) {
+                       $conf->diffusioncontact = new stdClass();
+               }
+
+               if (empty($conf->diffusioncontact->dir_output)) {
+                       $conf->diffusioncontact->dir_output = $conf->diffusionplans->dir_output.'/diffusioncontact';
+               }
+
+               if (empty($conf->diffusioncontact->multidir_output) || !is_array($conf->diffusioncontact->multidir_output)) {
+                       $conf->diffusioncontact->multidir_output = array();
+               }
+
+               if (empty($conf->diffusioncontact->multidir_output[$entity])) {
+                       $conf->diffusioncontact->multidir_output[$entity] = $conf->diffusioncontact->dir_output;
+               }
+
+               $this->modulepart = 'diffusioncontact';
+               $this->dir_output = $conf->diffusioncontact->multidir_output[$entity];
+
+               if (!empty($this->dir_output)) {
+                       dol_mkdir($this->dir_output);
+               }
+
+                if (!getDolGlobalInt('MAIN_SHOW_TECHNICAL_ID') && isset($this->fields['rowid']) && !empty($this->fields['ref'])) {
+                        $this->fields['rowid']['visible'] = 0;
 		}
 		if (!isModEnabled('multicompany') && isset($this->fields['entity'])) {
 			$this->fields['entity']['enabled'] = 0;

--- a/core/modules/modDiffusionPlans.class.php
+++ b/core/modules/modDiffusionPlans.class.php
@@ -83,8 +83,53 @@ class modDiffusionPlans extends DolibarrModules
 		// Key used in llx_const table to save module status enabled/disabled (where DIFFUSIONPLANS is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 
-		$conf->diffusionplans = new stdClass();
-    	$conf->diffusionplans->dir_output = './diffusionplans';
+                if (!isset($conf->diffusionplans) || !is_object($conf->diffusionplans)) {
+                        $conf->diffusionplans = new stdClass();
+                }
+
+                $entity = !empty($conf->entity) ? (int) $conf->entity : 1;
+                $defaultDir = DOL_DATA_ROOT.($entity > 1 ? '/'.$entity : '').'/diffusionplans';
+
+               if (empty($conf->diffusionplans->dir_output)) {
+                       $conf->diffusionplans->dir_output = $defaultDir;
+               }
+               if (empty($conf->diffusionplans->dir_temp)) {
+                       $conf->diffusionplans->dir_temp = $conf->diffusionplans->dir_output.'/temp';
+               }
+               if (empty($conf->diffusionplans->multidir_output) || !is_array($conf->diffusionplans->multidir_output)) {
+                       $conf->diffusionplans->multidir_output = array();
+               }
+               if (empty($conf->diffusionplans->multidir_output[$entity])) {
+                       $conf->diffusionplans->multidir_output[$entity] = $defaultDir;
+               }
+
+               $diffusionDir = $conf->diffusionplans->dir_output.'/diffusion';
+               if (!isset($conf->diffusion) || !is_object($conf->diffusion)) {
+                       $conf->diffusion = new stdClass();
+               }
+               if (empty($conf->diffusion->dir_output)) {
+                       $conf->diffusion->dir_output = $diffusionDir;
+               }
+               if (empty($conf->diffusion->multidir_output) || !is_array($conf->diffusion->multidir_output)) {
+                       $conf->diffusion->multidir_output = array();
+               }
+               if (empty($conf->diffusion->multidir_output[$entity])) {
+                       $conf->diffusion->multidir_output[$entity] = $diffusionDir;
+               }
+
+               $diffusionContactDir = $conf->diffusionplans->dir_output.'/diffusioncontact';
+               if (!isset($conf->diffusioncontact) || !is_object($conf->diffusioncontact)) {
+                       $conf->diffusioncontact = new stdClass();
+               }
+               if (empty($conf->diffusioncontact->dir_output)) {
+                       $conf->diffusioncontact->dir_output = $diffusionContactDir;
+               }
+               if (empty($conf->diffusioncontact->multidir_output) || !is_array($conf->diffusioncontact->multidir_output)) {
+                       $conf->diffusioncontact->multidir_output = array();
+               }
+               if (empty($conf->diffusioncontact->multidir_output[$entity])) {
+                       $conf->diffusioncontact->multidir_output[$entity] = $diffusionContactDir;
+               }
 
 		// Name of image file used for this module.
 		// If file is in theme/yourtheme/img directory under name object_pictovalue.png, use this->picto='pictovalue'
@@ -140,7 +185,11 @@ class modDiffusionPlans extends DolibarrModules
 
 		// Data directories to create when module is enabled.
 		// Example: this->dirs = array("/diffusionplans/temp","/diffusionplans/subdir");
-		$this->dirs = array("/diffusionplans/temp");
+                $this->dirs = array(
+                        "/diffusionplans/temp",
+                        "/diffusionplans/diffusion",
+                        "/diffusionplans/diffusioncontact",
+                );
 
 		// Config pages. Put here list of php page, stored into diffusionplans/admin directory, to use to setup module.
 		$this->config_page_url = array("setup.php@diffusionplans");


### PR DESCRIPTION
## Summary
- register diffusion and diffusioncontact modulepart directories in the module descriptor so CommonObject helpers can resolve absolute document roots
- align the runtime constructors with those shared definitions to keep modulepart output paths initialised for each entity

## Testing
- php -l class/diffusion.class.php
- php -l class/diffusioncontact.class.php
- php -l core/modules/modDiffusionPlans.class.php

------
https://chatgpt.com/codex/tasks/task_e_68e3b2453cd4832e81d5b5e32a971c42